### PR TITLE
quick hotfix

### DIFF
--- a/psahq horde shooter/Assets/Resources/Player.prefab
+++ b/psahq horde shooter/Assets/Resources/Player.prefab
@@ -545,7 +545,7 @@ GameObject:
   - component: {fileID: 8841242744199500019}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0


### PR DESCRIPTION
Player prefab has the 'player' tag in it which is needed in order to get the Camera field for the Noob enemy to be detected with the indicator arrows.